### PR TITLE
Bug: all layers above an ajustment layer have broken Layer.Channel.ImageData

### DIFF
--- a/PSDFile.cs
+++ b/PSDFile.cs
@@ -388,7 +388,7 @@ namespace System.Drawing.PSD
 
 			foreach (Layer layer in Layers)
 			{
-				foreach (Layer.Channel channel in layer.Channels.Where(c => c.ID != -2))
+				foreach (Layer.Channel channel in layer.Channels)
 				{
 					channel.LoadPixelData(reader);
 				}


### PR DESCRIPTION
In PsdFile.LoadLayers(), all channels must be read to consume bytestream.