### PR TITLE
Bug: all layers above a layer that has emtpy layer mask have broken Layer.Channel.ImageData

### DIFF
--- a/LayerMask.cs
+++ b/LayerMask.cs
@@ -173,7 +173,7 @@ namespace System.Drawing.PSD
 			{
 				Debug.WriteLine("Mask.LoadPixelData started at " + reader.BaseStream.Position.ToString(CultureInfo.InvariantCulture));
 
-				if (Rect.IsEmpty || Layer.SortedChannels.ContainsKey(-2) == false)
+				if (Layer.SortedChannels.ContainsKey(-2) == false)
 					return;
 
 				Channel maskChannel = Layer.SortedChannels[-2];
@@ -181,6 +181,8 @@ namespace System.Drawing.PSD
 
 				maskChannel.Data = reader.ReadBytes(maskChannel.Length);
 
+				if (Rect.IsEmpty)
+					return;
 
 				using (BinaryReverseReader readerImg = maskChannel.DataReader)
 				{


### PR DESCRIPTION
To consume bytestream, LoadPixelData() must read bytes of empty layer mask.

For example, an adjustment layer may have empty layer mask.
